### PR TITLE
Add GitHub actions for automatic builds

### DIFF
--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Build
-        run: make PREFIX=$RUNNER_TEMP/cross-mint
+        run: make PREFIX=$RUNNER_TEMP/cross-mint init_dirs binutils distrib
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v3

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -21,5 +21,5 @@ jobs:
       - name: Upload Artifact
         uses: actions/upload-artifact@v3
         with:
-          name: m68k-cross-mint-bin-darwin-arm64-*.tgz
+          name: m68k-cross-mint-bin tar ball
           path: packages/m68k-cross-mint-bin-darwin-arm64-*.tgz

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:
-    runs-on: self-hosted #macos-latest
+    runs-on: [self-hosted, macos-13]
 
     steps:
       - name: Checkout

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -15,6 +15,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Install prerequisites
+        run: brew install autoconf automake lzip
+
       - name: Build
         run: make PREFIX=$RUNNER_TEMP/cross-mint all
 

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Build
-        run: make PREFIX=$RUNNER_TEMP/cross-mint init_dirs binutils distrib
+        run: make PREFIX=$RUNNER_TEMP/cross-mint all
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v3

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -16,7 +16,7 @@ jobs:
         uses: actions/checkout@v3
 
       - name: Build
-        run: make
+        run: make PREFIX=$RUNNER_TEMP/cross-mint
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v3

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -1,0 +1,25 @@
+name: Build m68k-atari-mint-cross-tools
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    branches: [ "master" ]
+
+jobs:
+  build:
+    runs-on: macos-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+
+      - name: Build
+        run: make
+
+      - name: Upload Artifact
+        uses: actions/upload-artifact@v3
+        with:
+          name: m68k-cross-mint-bin-darwin-arm64-*.tgz
+          path: packages/m68k-cross-mint-bin-darwin-arm64-*.tgz

--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   build:
-    runs-on: macos-latest
+    runs-on: self-hosted #macos-latest
 
     steps:
       - name: Checkout

--- a/VARS
+++ b/VARS
@@ -11,7 +11,7 @@ PACKAGES_DIR=$(BASE_DIR)/packages
 PREFIX=/opt/cross-mint
 
 # Add search path for cross tools
-PATH:=$(PATH):/opt/cross-mint/bin
+PATH:=$(PATH):$(PREFIX)/bin
 
 # Default host architecture and system
 HOSTSYS=$(shell uname -s | tr "[:upper:]" "[:lower:]")


### PR DESCRIPTION
The goal of this PR is to create a GitHub action configuration which allows building the project on request and for verification of PRs.
Sadly the available GitHub runners are very slow and as we need to download bigger files from various locations for building the projects, only self-hosted runners are usable.