### PR TITLE
Fix VERSIONBUILD stability and unify root test/CI entrypoints

### DIFF
--- a/.github/workflows/make.yml
+++ b/.github/workflows/make.yml
@@ -22,10 +22,10 @@ jobs:
         run: make PREFIX=$RUNNER_TEMP/cross-mint all
 
       - name: Fast smoke tests
-        run: make -C tests PREFIX=$RUNNER_TEMP/cross-mint check
+        run: make PREFIX=$RUNNER_TEMP/cross-mint test
 
       - name: Full integration tests
-        run: make -C tests PREFIX=$RUNNER_TEMP/cross-mint check_all
+        run: make PREFIX=$RUNNER_TEMP/cross-mint test-all
 
       - name: Upload Artifact
         uses: actions/upload-artifact@v4

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ ARCH2=i386
 ##########################################
 all:	init_dirs binutils mintbin gcc gemlib libcmini distrib
 
-.PHONY: check_autoconf check_libtool
+.PHONY: check_autoconf check_libtool test test-all test-qed
 
 check_autoconf:
 	@command -v autoconf >/dev/null 2>&1 || { \
@@ -46,6 +46,15 @@ gcc4:	check_libtool $(BUILD_DIR)/gcclibs gcc464
 
 binutils mintbin mintlib pml fdlibm gemlib libcmini cflib qed gcc464 gcc-new gemma:	init_dirs
 	$(MAKE) -f Makefile.$@
+
+test:
+	$(MAKE) -C tests PREFIX="$(PREFIX)" check
+
+test-all:
+	$(MAKE) -C tests PREFIX="$(PREFIX)" check_all
+
+test-qed:
+	$(MAKE) -C tests PREFIX="$(PREFIX)" qed_build_check
 
 distrib:
 	cd "$(dir $(PREFIX))" && \

--- a/README.md
+++ b/README.md
@@ -61,6 +61,36 @@ make
 
 This will build and install the tool in `/opt/cross-mint` and will produce a "distribution package" in the `packages` directory.
 
+## Tests
+
+Basic test programs and checks are available in the `tests/` folder.
+
+Run fast smoke tests (hello world default/GEM/minimal):
+
+```bash
+make test
+```
+
+Run full integration tests (includes building and checking QED):
+
+```bash
+make test-all
+```
+
+Run only the QED build and checks:
+
+```bash
+make test-qed
+```
+
+When using a custom toolchain location (e.g. in CI), pass `PREFIX`:
+
+```bash
+make PREFIX=$RUNNER_TEMP/cross-mint all
+make PREFIX=$RUNNER_TEMP/cross-mint test
+make PREFIX=$RUNNER_TEMP/cross-mint test-all
+```
+
 ### Known problems
 
 On older macOS versions (e.g. macOS Sierra 10.13) where the `tar` command is unable to extract `bz2` or `lz` compressed files, you will encounter the error message `tar: Unrecognized archive format` while `gcclibs` is being executed.

--- a/VARS
+++ b/VARS
@@ -25,5 +25,12 @@ HOMEBREW_PREFIX=$(shell brew config | grep HOMEBREW_PREFIX | awk '{print $$2}')
 ##########################################
 VERSIONBIN=bin-$(HOSTSYS)
 VERSIONBINCPU=$(VERSIONBIN)-$(ARCH)
-VERSIONBUILD ?= $(shell date +%Y%m%d)
-VERSIONBUILD := $(VERSIONBUILD)
+VERSIONBUILD_FILE ?= $(BUILD_DIR)/.versionbuild
+VERSIONBUILD ?= $(shell mkdir -p "$(BUILD_DIR)"; \
+	if [ -f "$(VERSIONBUILD_FILE)" ]; then \
+		cat "$(VERSIONBUILD_FILE)"; \
+	else \
+		date +%Y%m%d > "$(VERSIONBUILD_FILE)"; \
+		cat "$(VERSIONBUILD_FILE)"; \
+	fi)
+VERSIONBUILD := $(strip $(VERSIONBUILD))

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -5,7 +5,7 @@ CC = $(PREFIX)/bin/$(TARGET)-gcc
 OBJDUMP = $(PREFIX)/bin/$(TARGET)-objdump
 FILE_CMD ?= file
 
-BUILD_DIR ?= build
+TEST_BUILD_DIR ?= build
 LIBCMINI_ROOT ?= $(PREFIX)/m68k-atari-mint/libcmini
 ROOT_DIR ?= ..
 
@@ -17,10 +17,10 @@ LIBCMINI_CFLAGS ?= -I$(LIBCMINI_ROOT)/include
 LIBCMINI_LDFLAGS ?= -s -nostdlib $(LIBCMINI_ROOT)/lib/crt0.o
 LIBCMINI_LDLIBS ?= -L$(LIBCMINI_ROOT)/lib -lgcc -lcmini -lgcc
 
-HELLO_DEFAULT_BIN := $(BUILD_DIR)/hello-default.tos
-HELLO_MINIMAL_OBJ := $(BUILD_DIR)/hello-minimal.o
-HELLO_MINIMAL_BIN := $(BUILD_DIR)/hello-minimal.tos
-HELLO_GEM_BIN := $(BUILD_DIR)/hello-gem.prg
+HELLO_DEFAULT_BIN := $(TEST_BUILD_DIR)/hello-default.tos
+HELLO_MINIMAL_OBJ := $(TEST_BUILD_DIR)/hello-minimal.o
+HELLO_MINIMAL_BIN := $(TEST_BUILD_DIR)/hello-minimal.tos
+HELLO_GEM_BIN := $(TEST_BUILD_DIR)/hello-gem.prg
 
 .PHONY: all clean check check_all \
 	hello_world hello_world_gem hello_world_minimal \
@@ -53,22 +53,22 @@ qed_check:
 qed_build_check: qed_build qed_check
 	@echo "QED build and validation passed."
 
-$(BUILD_DIR):
+$(TEST_BUILD_DIR):
 	mkdir -p "$@"
 
-$(HELLO_DEFAULT_BIN): hello.c | $(BUILD_DIR)
+$(HELLO_DEFAULT_BIN): hello.c | $(TEST_BUILD_DIR)
 	$(CC) $(CFLAGS_COMMON) $(LDFLAGS_COMMON) -o "$@" "$<" $(LDLIBS_COMMON)
 	@$(FILE_CMD) "$@" | grep -q "Atari ST M68K contiguous executable"
 	@$(OBJDUMP) -f "$@" | grep -q "file format a.out-mintprg"
 	@$(OBJDUMP) -t "$@" | grep -q "___libc_main"
 
-$(HELLO_GEM_BIN): hello_gem.c | $(BUILD_DIR)
+$(HELLO_GEM_BIN): hello_gem.c | $(TEST_BUILD_DIR)
 	$(CC) $(CFLAGS_COMMON) -o "$@" "$<" -lgem
 	@$(FILE_CMD) "$@" | grep -q "Atari ST M68K contiguous executable"
 	@$(OBJDUMP) -f "$@" | grep -q "file format a.out-mintprg"
 	@$(OBJDUMP) -t "$@" | grep -q "_mt_form_alert"
 
-$(HELLO_MINIMAL_OBJ): hello.c | $(BUILD_DIR)
+$(HELLO_MINIMAL_OBJ): hello.c | $(TEST_BUILD_DIR)
 	$(CC) $(CFLAGS_COMMON) $(LIBCMINI_CFLAGS) -c -o "$@" "$<"
 
 $(HELLO_MINIMAL_BIN): $(HELLO_MINIMAL_OBJ)
@@ -79,4 +79,4 @@ $(HELLO_MINIMAL_BIN): $(HELLO_MINIMAL_OBJ)
 	@test "$$(wc -c < "$@")" -lt "$$(wc -c < "$(HELLO_DEFAULT_BIN)")"
 
 clean:
-	rm -rf "$(BUILD_DIR)"
+	rm -rf "$(TEST_BUILD_DIR)"


### PR DESCRIPTION
## Summary
- fix `VERSIONBUILD` handling in `VARS` so sub-makes share a stable build date across long-running builds/restarts
- add top-level test entrypoints in `Makefile`:
  - `make test`
  - `make test-all`
  - `make test-qed`
- update `tests/Makefile` to avoid `BUILD_DIR` collisions when called from root make
- document test usage in `README.md`
- align CI workflow commands with root test entrypoints (`make test`, `make test-all`)

## Files changed
- `.github/workflows/make.yml`
- `Makefile`
- `README.md`
- `VARS`
- `tests/Makefile`

Fixes #9